### PR TITLE
Add MockSimCtl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
+
+### Added
+
+- `MockSimCtl` class https://github.com/tuist/simulator/pull/2 by @pepibumur

--- a/Tests/SimulatorTests/AnyError.swift
+++ b/Tests/SimulatorTests/AnyError.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+struct AnyError: Error {}

--- a/Tests/SimulatorTests/MockSimCtl.swift
+++ b/Tests/SimulatorTests/MockSimCtl.swift
@@ -1,0 +1,20 @@
+import Foundation
+@testable import Simulator
+
+final class MockSimCtl: SimCtling {
+    
+    private var stubs: [[String]: Any] =  [:]
+    
+    func simctl(_ arguments: String...) throws -> String {
+        guard let stub = stubs[arguments] else {
+            throw AnyError()
+        }
+        let data = try JSONSerialization.data(withJSONObject: stub, options: [])
+        return String.init(data: data, encoding: .utf8) ?? ""
+    }
+    
+    func stub(_ arguments: String..., with: Any) {
+        stubs[arguments] = with
+    }
+    
+}


### PR DESCRIPTION
### Short description 📝
Add a `MockSimCtl` class that can be used for testing purposes. It exposes a method that allows stubbing the simctl response for any given command.

### Implementation 👩‍💻👨‍💻

- [x] Add `MockSimCtl` class.