### PR TITLE
Rename SimCtl to Shell

### DIFF
--- a/Sources/simulator/Device.swift
+++ b/Sources/simulator/Device.swift
@@ -74,18 +74,18 @@ public class Device: Decodable, Equatable {
     /// - Returns: List of devices.
     /// - Throws: An error if the simctl command fails.
     public static func list() throws -> [Device] {
-        return try list(simctl: SimCtl.shared)
+        return try list(shell: Shell.shared)
     }
 
     // MARK: - Internal
 
     /// Gets the list of devices from the system.
     ///
-    /// - Parameter simctl: Instace of SimCtl to run the commands.
+    /// - Parameter shell: Instance of shell to run the commands.
     /// - Returns: List of devices.
     /// - Throws: An error if the simctl command fails.
-    static func list(simctl: SimCtling) throws -> [Device] {
-        let data = try simctl.simctl("list", "-j", "devices")
+    static func list(shell: Shelling) throws -> [Device] {
+        let data = try shell.simctl("list", "-j", "devices")
         let decoder = JSONDecoder()
 
         guard let dictionary = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],

--- a/Sources/simulator/Shell.swift
+++ b/Sources/simulator/Shell.swift
@@ -1,8 +1,8 @@
 import Foundation
 import ReactiveTask
 
-/// Protocol that defines the interface of an entity that runs simctl commands.
-protocol SimCtling {
+/// Protocol that defines the interface of an entity that runs shell commands.
+protocol Shelling {
     /// Runs simctl with the given arguments.
     ///
     /// - Parameter arguments: Arguments to be passed to simctl.
@@ -19,10 +19,10 @@ enum SimCtlError: Error {
     case noResult
 }
 
-/// Struct that conforms the SimCtling providing a default implementation.
-struct SimCtl: SimCtling {
-    /// Shared instance of SimCtl.
-    public static let shared: SimCtling = SimCtl()
+/// Struct that conforms the Shelling providing a default implementation.
+struct Shell: Shelling {
+    /// Shared instance of Shell.
+    public static let shared: Shelling = Shell()
 
     /// Runs simctl with the given arguments.
     ///

--- a/Tests/SimulatorTests/DeviceTests.swift
+++ b/Tests/SimulatorTests/DeviceTests.swift
@@ -3,11 +3,11 @@ import Foundation
 import XCTest
 
 final class DeviceTests: XCTestCase {
-    var simctl: MockSimCtl!
+    var shell: MockShell!
 
     override func setUp() {
         super.setUp()
-        simctl = MockSimCtl()
+        shell = MockShell()
     }
 
     func test_list_returns_a_non_empty_list() throws {
@@ -16,7 +16,7 @@ final class DeviceTests: XCTestCase {
     }
 
     func test_list_maps_the_devices() throws {
-        simctl.stub("list", "-j", "devices", with: [
+        shell.stub("list", "-j", "devices", with: [
             "devices": [
                 "iOS 12.1": [
                     [
@@ -30,7 +30,7 @@ final class DeviceTests: XCTestCase {
                 ],
             ],
         ])
-        let got = try Device.list(simctl: simctl)
+        let got = try Device.list(shell: shell)
         XCTAssertEqual(got.count, 1)
 
         XCTAssertEqual(got.first?.availability, "(unavailable, runtime profile not found)")

--- a/Tests/SimulatorTests/MockShell.swift
+++ b/Tests/SimulatorTests/MockShell.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import Simulator
 
-final class MockSimCtl: SimCtling {
+final class MockShell: Shelling {
     private var stubs: [[String]: Any] = [:]
 
     func simctl(_ arguments: String...) throws -> Data {

--- a/Tests/SimulatorTests/ShellTests.swift
+++ b/Tests/SimulatorTests/ShellTests.swift
@@ -2,12 +2,12 @@ import Foundation
 @testable import Simulator
 import XCTest
 
-final class SimCtlTests: XCTestCase {
-    var subject: SimCtl!
+final class ShellTests: XCTestCase {
+    var subject: Shell!
 
     override func setUp() {
         super.setUp()
-        subject = SimCtl()
+        subject = Shell()
     }
 
     func test_simctl() throws {


### PR DESCRIPTION
### Short description 📝
Rename `SimCtl` and `SimCtlling` to `Shell` and `Shelling` respectively. We'll need to run more commands on the shell other than `simctl` so I renamed the class to be more generic and have it as a place where we can add other shell helper methods.