### PR TITLE
Use SwiftShell instead of ReactiveTask

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: '10.0.0'
+      xcode: '10.1.0'
     steps:
       - checkout
       - run:

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,48 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "package": "SwiftShell",
+        "repositoryURL": "https://github.com/kareman/SwiftShell.git",
         "state": {
           "branch": null,
-          "revision": "cd6dfb86f496fcd96ce0bc6da962cd936bf41903",
-          "version": "7.3.1"
-        }
-      },
-      {
-        "package": "Quick",
-        "repositoryURL": "https://github.com/Quick/Quick.git",
-        "state": {
-          "branch": null,
-          "revision": "5fbf13871d185526993130c3a1fad0b70bfe37ce",
-          "version": "1.3.2"
-        }
-      },
-      {
-        "package": "ReactiveSwift",
-        "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "4f6a12ae6762e825b0e19a4f7076eafa43847e6e",
-          "version": "4.0.0"
-        }
-      },
-      {
-        "package": "ReactiveTask",
-        "repositoryURL": "https://github.com/Carthage/ReactiveTask.git",
-        "state": {
-          "branch": null,
-          "revision": "0f3be6022e2435e1bb91679bc2aabeff13eb794c",
-          "version": "0.15.0"
-        }
-      },
-      {
-        "package": "Result",
-        "repositoryURL": "https://github.com/antitypical/Result.git",
-        "state": {
-          "branch": null,
-          "revision": "8fc088dcf72802801efeecba76ea8fb041fb773d",
-          "version": "4.0.0"
+          "revision": "beebe43c986d89ea5359ac3adcb42dac94e5e08a",
+          "version": "4.1.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -8,12 +8,12 @@ let package = Package(
         .library(name: "Simulator", type: .dynamic, targets: ["Simulator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Carthage/ReactiveTask.git", .upToNextMinor(from: "0.15.0")),
+        .package(url: "https://github.com/kareman/SwiftShell.git", .upToNextMinor(from: "4.1.2")),
     ],
     targets: [
         .target(
             name: "Simulator",
-            dependencies: ["ReactiveTask"]
+            dependencies: ["SwiftShell"]
         ),
         .testTarget(
             name: "SimulatorTests",

--- a/Sources/simulator/Shell.swift
+++ b/Sources/simulator/Shell.swift
@@ -1,24 +1,53 @@
 import Foundation
-import ReactiveSwift
-import ReactiveTask
-import Result
+import SwiftShell
 
-/// Contains all the errors that are returned by the Shell signal producers.
-///
-/// - taskError: Error returned by the underlying task run in the system.
-/// - nonUtf8Output: Thrown when an output expected to be of type utf8 has a different type.
-public enum ShellError: Error, CustomStringConvertible {
-    case taskError(TaskError)
-    case nonUtf8Output
+/// This structs wraps the SwiftShell RunOutput to facilitate testing.
+/// The RunOutput doesn't provide any initializer that that initializes the result with its properties.
+struct ShellOutput {
+    /// Standard output string.
+    let stdout: String
 
-    /// Error description.
-    public var description: String {
-        switch self {
-        case let .taskError(error):
-            return "Error running task: \(error)"
-        case .nonUtf8Output:
-            return "Expected output to have a valid utf8 format but got a different format."
-        }
+    /// Standard error string.
+    let stderror: String
+
+    /// Command exit code.
+    let exitcode: Int
+
+    /// True if the command succeeded.
+    let succeeded: Bool
+
+    /// Command error.
+    let error: Error?
+
+    /// Initializes the shell output with the SwiftShell RunOutput
+    ///
+    /// - Parameter output: Output from running a shell command.
+    init(_ output: RunOutput) {
+        stdout = output.stdout
+        stderror = output.stderror
+        exitcode = output.exitcode
+        succeeded = output.succeeded
+        error = output.error
+    }
+
+    /// Initializes the ShellOutput with its attributes.
+    ///
+    /// - Parameters:
+    ///   - stdout: Standard output string.
+    ///   - stderror: Standard error string.
+    ///   - exitcode: Command exit code.
+    ///   - succeeded: True if the command succeeded.
+    ///   - error: Command error.
+    init(stdout: String = "",
+         stderror: String = "",
+         exitcode: Int = 0,
+         succeeded: Bool = true,
+         error: Error? = nil) {
+        self.stdout = stdout
+        self.stderror = stderror
+        self.exitcode = exitcode
+        self.succeeded = succeeded
+        self.error = error
     }
 }
 
@@ -26,42 +55,42 @@ public enum ShellError: Error, CustomStringConvertible {
 protocol Shelling {
     /// Runs the open command with the given arguments.
     ///
-    /// - Parameter arguments: Arguments to be passed to the open command.
-    /// - Returns: A signal producer that runs the command.
-    func open(_ arguments: [String]) -> SignalProducer<Void, ShellError>
+    /// - Parameter arguments: Arguments to be passed to open.
+    /// - Throws: A CommandError if the open command fails.
+    func open(_ arguments: [String]) throws
 
     /// Runs simctl with the given arguments.
     ///
     /// - Parameter arguments: Arguments to be passed to simctl.
-    /// - Returns: A signal producer that runs the simctl command.
-    func simctl(_ arguments: [String]) -> SignalProducer<TaskEvent<Data>, ShellError>
+    /// - Returns: The command output.
+    /// - Throws: A CommandError if the command fails.
+    func simctl(_ arguments: [String]) throws -> ShellOutput
 
     /// Runs xcrun with the given arguments.
     ///
     /// - Parameter arguments: Arguments to be passed to xcrun.
-    /// - Returns: A signal producer that runs the xcrun command.
-    func xcrun(_ arguments: [String]) -> SignalProducer<TaskEvent<Data>, ShellError>
-
-    /// Returns a signal producer that runs the which command with the given name.
-    /// If the tool with the given name is available in the environment, the producer will return
-    /// the path to the tool.
+    /// - Returns: The output from running the command.
+    /// - Throws: A CommandError if the command fails.
+    func xcrun(_ arguments: [String]) throws -> ShellOutput
+    /// It runs which with the given tool.
     ///
-    /// - Parameter name: Argument to be passed to the which command.
-    /// - Returns: A signal producer that runs the command.
-    func which(_ name: String) -> SignalProducer<String, ShellError>
-
-    /// Returns a signal producer that runs the given command on the shell.
+    /// - Parameter name: Name of the tool.
+    /// - Returns: Which result.
+    /// - Throws: CommandError if the command fails.
+    func which(_ name: String) throws -> String
+    /// Runs a command in the shell.
     ///
     /// - Parameters:
     ///   - launchPath: Path to be launched.
     ///   - arguments: List of arguments to be passed to the command.
-    /// - Returns: A signal producer that triggers the command when subscribers subscribe to it.
-    func run(launchPath: String, arguments: [String]) -> SignalProducer<TaskEvent<Data>, ShellError>
+    /// - Returns: The output from running the command.
+    func run(launchPath: String, arguments: [String]) -> ShellOutput
 
-    /// It returns a signal producer that gets the Xcode path using xcode-select.
+    /// It returns the Xcode path using xcode-select.
     ///
-    /// - Returns: Signal producer that gets the Xcode path.
-    func xcodePath() -> SignalProducer<String, ShellError>
+    /// - Returns: Xcode path.
+    /// - Throws: CommandError if the command fails.
+    func xcodePath() throws -> String
 }
 
 /// Struct that conforms the Shelling providing a default implementation.
@@ -73,80 +102,77 @@ struct Shell: Shelling {
 
     /// Runs the open command with the given arguments.
     ///
-    /// - Parameter arguments: Arguments to be passed to the open command.
-    /// - Returns: A signal producer that runs the command.
-    func open(_ arguments: [String]) -> SignalProducer<Void, ShellError> {
-        return run(launchPath: "/usr/bin/open", arguments: arguments).map(value: ())
+    /// - Parameter arguments: Arguments to be passed to open.
+    /// - Throws: A CommandError if the open command fails.
+    func open(_ arguments: [String]) throws {
+        let output = run(launchPath: "/usr/bin/open", arguments: arguments)
+        if let error = output.error {
+            throw error
+        }
     }
 
     /// Runs simctl with the given arguments.
     ///
     /// - Parameter arguments: Arguments to be passed to simctl.
-    /// - Returns: A signal producer that runs the simctl command.
-    func simctl(_ arguments: [String]) -> SignalProducer<TaskEvent<Data>, ShellError> {
+    /// - Returns: The command output.
+    /// - Throws: A CommandError if the command fails.
+    func simctl(_ arguments: [String]) throws -> ShellOutput {
         var arguments = arguments
         arguments.insert("simctl", at: 0)
-        return xcrun(arguments)
+        return try xcrun(arguments)
     }
 
     /// Runs xcrun with the given arguments.
     ///
     /// - Parameter arguments: Arguments to be passed to xcrun.
-    /// - Returns: A signal producer that runs the xcrun command.
-    func xcrun(_ arguments: [String]) -> SignalProducer<TaskEvent<Data>, ShellError> {
-        return xcrunPath()
-            .flatMap(.latest, { (path: String) -> SignalProducer<TaskEvent<Data>, ShellError> in
-                self.run(launchPath: path, arguments: arguments)
-            })
+    /// - Returns: The output from running the command.
+    /// - Throws: A CommandError if the command fails.
+    func xcrun(_ arguments: [String]) throws -> ShellOutput {
+        let path = try xcrunPath()
+        return run(launchPath: path, arguments: arguments)
     }
 
-    /// Returns a signal producer that runs the which command with the given name.
-    /// If the tool with the given name is available in the environment, the producer will return
-    /// the path to the tool.
+    /// It runs which with the given tool.
     ///
-    /// - Parameter name: Argument to be passed to the which command.
-    /// - Returns: A signal producer that runs the command.
-    func which(_ name: String) -> SignalProducer<String, ShellError> {
-        return run(launchPath: "/usr/bin/which", arguments: [name])
-            .ignoreTaskData()
-            .flatMap(.latest, { (data: Data) -> SignalProducer<String, ShellError> in
-                guard let path: String = String(data: data, encoding: .utf8) else {
-                    return SignalProducer(error: ShellError.nonUtf8Output)
-                }
-                return SignalProducer(value: path.spm_chomp())
-            })
+    /// - Parameter name: Name of the tool.
+    /// - Returns: Which result.
+    /// - Throws: CommandError if the command fails.
+    func which(_ name: String) throws -> String {
+        let output = run(launchPath: "/usr/bin/which", arguments: [name])
+        if let error = output.error {
+            throw error
+        }
+        return output.stdout.spm_chomp()
     }
 
-    /// Returns a signal producer that runs the given command on the shell.
+    /// Runs a command in the shell.
     ///
     /// - Parameters:
     ///   - launchPath: Path to be launched.
     ///   - arguments: List of arguments to be passed to the command.
-    /// - Returns: A signal producer that triggers the command when subscribers subscribe to it.
-    func run(launchPath: String, arguments: [String]) -> SignalProducer<TaskEvent<Data>, ShellError> {
-        return Task(launchPath, arguments: arguments).launch().mapError({ ShellError.taskError($0) })
+    /// - Returns: The output from running the command.
+    func run(launchPath: String, arguments: [String]) -> ShellOutput {
+        return ShellOutput(SwiftShell.run(launchPath, arguments))
     }
 
-    /// It returns a signal producer that gets the Xcode path using xcode-select.
+    /// It returns the Xcode path using xcode-select.
     ///
-    /// - Returns: Signal producer that gets the Xcode path.
-    func xcodePath() -> SignalProducer<String, ShellError> {
-        return run(launchPath: "/usr/bin/xcode-select", arguments: ["-p"])
-            .ignoreTaskData()
-            .flatMap(.latest, { (data: Data) -> SignalProducer<String, ShellError> in
-                guard let path: String = String(data: data, encoding: .utf8) else {
-                    return SignalProducer(error: ShellError.nonUtf8Output)
-                }
-                return SignalProducer(value: path.spm_chomp())
-            })
+    /// - Returns: Xcode path.
+    /// - Throws: CommandError if the command fails.
+    func xcodePath() throws -> String {
+        let output = run(launchPath: "/usr/bin/xcode-select", arguments: ["-p"])
+        if let error = output.error {
+            throw error
+        }
+        return output.stdout.spm_chomp()
     }
 
     // MARK: - Fileprivate
 
-    /// Returns a signal producer that returns the path of xcrun.
+    /// Returns the path to xcrun.
     ///
     /// - Returns: Path where xcrun is located in the system.
-    fileprivate func xcrunPath() -> SignalProducer<String, ShellError> {
-        return which("xcrun")
+    fileprivate func xcrunPath() throws -> String {
+        return try which("xcrun")
     }
 }

--- a/Sources/simulator/SimulatorError.swift
+++ b/Sources/simulator/SimulatorError.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftShell
 
 /// Simulator errors.
 ///
@@ -13,7 +14,6 @@ import Foundation
 /// - invalidLaunchCtlListOutput: Thrown when the output from the launchtl list command cannot be parsed.
 public enum SimulatorError: Error {
     case noOutput
-    case shell(ShellError)
     case jsonSerialize(Error)
     case jsonDecode(Error)
     case invalidFormat

--- a/Sources/simulator/Xcode.swift
+++ b/Sources/simulator/Xcode.swift
@@ -1,19 +1,19 @@
 import Foundation
-import ReactiveSwift
 
 protocol Xcoding {
-    /// Returns a signal producer that returns the path where the platform simulator
+    /// Returns the path to the platform simulator SDK.
     ///
-    /// - Parameters:
-    ///   - platform: Platform whose simulator SDK path will be returned
-    /// - Returns: Signal producer that returns the path where the platform simulator SDK is located.
-    func simulatorSDKPath(platform: Runtime.Platform) -> SignalProducer<URL?, ShellError>
+    /// - Parameter platform: Simulator platform.
+    /// - Returns: Path to the simulator SDK.
+    /// - Throws: An error if the path cannot be obtained.
+    func simulatorSDKPath(platform: Runtime.Platform) throws -> URL?
 
-    /// Returns a signal producer that returns the path where the platform simulator runtimes are located.
+    /// Returns the path where the platform simulator runtimes are located.
     ///
     /// - Parameter platform: Platform whose runtime profiles will be returned.
-    /// - Returns: Signal producer that returns the path.
-    func runtimeProfilesPath(platform: Runtime.Platform) -> SignalProducer<URL?, ShellError>
+    /// - Returns: Path to the simulator runtimes.
+    /// - Throws: An error if the path cannot be obtained.
+    func runtimeProfilesPath(platform: Runtime.Platform) throws -> URL?
 }
 
 /// Struct that provides some helper methods to read information from the Xcode environment.
@@ -32,31 +32,30 @@ struct Xcode: Xcoding {
         self.shell = shell
     }
 
-    /// Returns a signal producer that returns the path where the platform simulator runtimes are located.
+    /// Returns the path to the platform simulator SDK.
     ///
-    /// - Parameter platform: Platform whose runtime profiles will be returned.
-    /// - Returns: Signal producer that returns the path.
-    func runtimeProfilesPath(platform: Runtime.Platform) -> SignalProducer<URL?, ShellError> {
+    /// - Parameter platform: Simulator platform.
+    /// - Returns: Path to the simulator SDK.
+    /// - Throws: An error if the path cannot be obtained.
+    func runtimeProfilesPath(platform: Runtime.Platform) throws -> URL? {
         guard let device = devicePlatform(platform: platform) else {
-            return SignalProducer(value: nil)
+            return nil
         }
-        return shell.xcodePath()
-            .map({ URL(fileURLWithPath: $0, isDirectory: true) })
-            .map({ $0.appendingPathComponent("Platforms/\(device).platform/Developer/Library/CoreSimulator/Profiles/Runtimes/") })
+        let path = try URL(fileURLWithPath: shell.xcodePath(), isDirectory: true)
+        return path.appendingPathComponent("Platforms/\(device).platform/Developer/Library/CoreSimulator/Profiles/Runtimes/")
     }
 
-    /// Returns a signal producer that returns the path where the platform simulator
+    /// Returns the path where the platform simulator runtimes are located.
     ///
-    /// - Parameters:
-    ///   - platform: Platform whose simulator SDK path will be returned
-    /// - Returns: Signal producer that returns the path where the platform simulator SDK is located.
-    func simulatorSDKPath(platform: Runtime.Platform) -> SignalProducer<URL?, ShellError> {
+    /// - Parameter platform: Platform whose runtime profiles will be returned.
+    /// - Returns: Path to the simulator runtimes.
+    /// - Throws: An error if the path cannot be obtained.
+    func simulatorSDKPath(platform: Runtime.Platform) throws -> URL? {
         guard let simulator = simulatorPlatform(platform: platform) else {
-            return SignalProducer(value: nil)
+            return nil
         }
-        return shell.xcodePath()
-            .map({ URL(fileURLWithPath: $0, isDirectory: true) })
-            .map({ $0.appendingPathComponent("Platforms/\(simulator).platform/Developer/SDKs/\(simulator).sdk/") })
+        let path = try URL(fileURLWithPath: shell.xcodePath(), isDirectory: true)
+        return path.appendingPathComponent("Platforms/\(simulator).platform/Developer/SDKs/\(simulator).sdk/")
     }
 
     /// Given a platform, it returns the name of the simulator platform to look it up in the Developer/Platforms directory.

--- a/Tests/SimulatorTests/DeviceTests.swift
+++ b/Tests/SimulatorTests/DeviceTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 @testable import Simulator
 import XCTest
 
@@ -78,33 +77,5 @@ final class DeviceTests: XCTestCase {
     func test_list_returns_a_non_empty_list() throws {
         let got = try Device.list()
         XCTAssertNotEqual(got.count, 0)
-    }
-
-    func test_list_maps_the_devices() throws {
-        let output = [
-            "devices": [
-                "iOS 12.1": [
-                    [
-                        "availability": "(unavailable, runtime profile not found)",
-                        "state": "Shutdown",
-                        "isAvailable": false,
-                        "name": "iPhone 6 Plus",
-                        "udid": "xxx",
-                        "availabilityError": "runtime profile not found",
-                    ],
-                ],
-            ],
-        ]
-        shell.stubSimctl(["list", "-j", "devices"], result: Result.success(output))
-        let got = Device.Reactive.list(shell: shell).single()?.value ?? []
-        XCTAssertEqual(got.count, 1)
-
-        XCTAssertEqual(got.first?.availability, "(unavailable, runtime profile not found)")
-        XCTAssertEqual(got.first?.state, "Shutdown")
-        XCTAssertEqual(got.first?.isAvailable, false)
-        XCTAssertEqual(got.first?.name, "iPhone 6 Plus")
-        XCTAssertEqual(got.first?.udid, "xxx")
-        XCTAssertEqual(got.first?.availabilityError, "runtime profile not found")
-        XCTAssertEqual(got.first?.runtimeName, "iOS 12.1")
     }
 }

--- a/Tests/SimulatorTests/Mocks/MockXcode.swift
+++ b/Tests/SimulatorTests/Mocks/MockXcode.swift
@@ -1,27 +1,17 @@
 import Foundation
-import ReactiveSwift
-import ReactiveTask
-import Result
+import SwiftShell
 
 @testable import Simulator
 
 final class MockXcode: Xcoding {
-    var simulatorSDKPathStub: ((Runtime.Platform) -> Result<URL?, ShellError>)?
-    var runtimeProfilesPathStub: ((Runtime.Platform) -> Result<URL?, ShellError>)?
+    var simulatorSDKPathStub: ((Runtime.Platform) throws -> URL?)?
+    var runtimeProfilesPathStub: ((Runtime.Platform) throws -> URL?)?
 
-    func simulatorSDKPath(platform: Runtime.Platform) -> SignalProducer<URL?, ShellError> {
-        if let result = simulatorSDKPathStub?(platform) {
-            return SignalProducer(result: result)
-        } else {
-            return SignalProducer(value: nil)
-        }
+    func simulatorSDKPath(platform: Runtime.Platform) throws -> URL? {
+        return try simulatorSDKPathStub?(platform)
     }
 
-    func runtimeProfilesPath(platform: Runtime.Platform) -> SignalProducer<URL?, ShellError> {
-        if let result = runtimeProfilesPathStub?(platform) {
-            return SignalProducer(result: result)
-        } else {
-            return SignalProducer(value: nil)
-        }
+    func runtimeProfilesPath(platform: Runtime.Platform) throws -> URL? {
+        return try runtimeProfilesPathStub?(platform)
     }
 }

--- a/Tests/SimulatorTests/ShellTests.swift
+++ b/Tests/SimulatorTests/ShellTests.swift
@@ -11,8 +11,7 @@ final class ShellTests: XCTestCase {
     }
 
     func test_simctl() throws {
-        let data = subject.simctl(["help"]).ignoreTaskData().single()?.value ?? Data()
-        let output = String(data: data, encoding: .utf8) ?? ""
+        let output = try subject.simctl(["help"]).stdout
         XCTAssertTrue(output.contains("Command line utility to control the Simulator"))
     }
 }

--- a/Tests/SimulatorTests/XcodeTests.swift
+++ b/Tests/SimulatorTests/XcodeTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 @testable import Simulator
 import XCTest
 
@@ -14,45 +13,29 @@ final class XcodeTests: XCTestCase {
     }
 
     func test_runtimeProfilesPath() throws {
-        shell.xcodePathStub = {
-            .success("/xcode")
-        }
-        guard let got = subject.runtimeProfilesPath(platform: .iOS).single() else {
+        shell.xcodePathStub = { "/xcode" }
+        guard let got = try subject.runtimeProfilesPath(platform: .iOS) else {
             XCTFail("Expected simulatorSDKPath to return a value")
             return
         }
-        let value = try XCTTry(try got.dematerialize())
-        XCTAssertEqual(value, URL(fileURLWithPath: "/xcode/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes"))
+        XCTAssertEqual(got, URL(fileURLWithPath: "/xcode/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes"))
     }
 
     func test_runtimeProfilesPath_when_platformHasNoSimulator() throws {
-        guard let got = subject.runtimeProfilesPath(platform: .unknown).single() else {
-            XCTFail("Expected simulatorSDKPath to return a value")
-            return
-        }
-        let value = try XCTTry(try got.dematerialize())
-        XCTAssertNil(value)
+        XCTAssertNil(try subject.runtimeProfilesPath(platform: .unknown))
     }
 
     func test_simulatorSDKPath() throws {
-        shell.xcodePathStub = {
-            .success("/xcode")
-        }
-        guard let got = subject.simulatorSDKPath(platform: .iOS).single() else {
+        shell.xcodePathStub = { "/xcode" }
+        guard let got = try subject.simulatorSDKPath(platform: .iOS) else {
             XCTFail("Expected simulatorSDKPath to return a value")
             return
         }
-        let value = try XCTTry(try got.dematerialize())
-        XCTAssertEqual(value, URL(fileURLWithPath: "/xcode/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"))
+        XCTAssertEqual(got, URL(fileURLWithPath: "/xcode/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"))
     }
 
     func test_simulatorSDKPath_when_platformHasNoSimulators() throws {
-        guard let got = subject.simulatorSDKPath(platform: .unknown).single() else {
-            XCTFail("Expected simulatorSDKPath to return a value")
-            return
-        }
-        let value = try XCTTry(try got.dematerialize())
-        XCTAssertNil(value)
+        XCTAssertNil(try subject.simulatorSDKPath(platform: .unknown))
     }
 
     func test_devicePlatform() throws {


### PR DESCRIPTION
### Short description 📝
Updates the project to use SwiftShell instead of ReactiveTask. The benefits of using `SwiftShell` are:
- We don't depend on a whole reactive library.
- We can have support for both, CocoaPods and Carthage.
- It simplifies the implementation.

In a follow-up PR I'll add support for Carthage and CocoaPods.