### PR TITLE
Add wait method to Device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Replace SwiftShell with Shell https://github.com/tuist/simulator/pull/10 by @pepibumur
 
+### Added
+
+- `Device.reload` method https://github.com/tuist/simulator/pull/11 by @pepibumur.
+- `Device.wait` method https://github.com/tuist/simulator/pull/11 by @pepibumur.
+
 ## 0.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ let devices = try Device.list
 // Launch simulator
 try device.launch()
 
+// Wait until the simulator is launched
+try device.wait(until: { $0.isBooted })
+
 // Install an app
 let appPath = URL(fileURLWithPath: "/path/App.app")
 try device.install(appPath)
@@ -86,6 +89,6 @@ Tuist is a proud supporter of the [Software Freedom Conservacy](https://sfconser
 
 <a href="https://sfconservancy.org/supporter/"><img src="https://sfconservancy.org/img/supporter-badge.png" width="194" height="90" alt="Become a Conservancy Supporter!" border="0"/></a>
 
-
 ## License
+
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Ftuist%2Fsimulator.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Ftuist%2Fsimulator?ref=badge_large)

--- a/Sources/simulator/SimulatorError.swift
+++ b/Sources/simulator/SimulatorError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum SimulatorError: Error {
+public enum SimulatorError: Error, CustomStringConvertible {
     /// Thrown the underlying command doesn't return any output.
     case noOutput
 
@@ -30,4 +30,38 @@ public enum SimulatorError: Error {
 
     /// Thrown when a command exits unsuccessfully
     case shellError(String?)
+
+    /// Thrown when the method times out.
+    case timeoutError
+
+    public var description: String {
+        switch self {
+        case .noOutput:
+            return "The command returned no output"
+        case let .jsonSerialize(error):
+            return "Error serializing the JSON output: \(error)"
+        case let .jsonDecode(error):
+            return "Error decoding the JSON output: \(error)"
+        case .invalidFormat:
+            return "Unexpected output format"
+        case .deviceTypeNotFound:
+            return "Device type not found"
+        case .runtimeNotFound:
+            return "Runtime not found"
+        case .runtimeProfileNotFound:
+            return "Runtime profile not found"
+        case .invalidLaunchCtlListOutput:
+            return "Invalid launchctl output"
+        case .xcodeNotFound:
+            return "Xcode not found running xcode-select"
+        case let .shellError(error):
+            if let error = error {
+                return "Error running command: \(error)"
+            } else {
+                return "Error running command"
+            }
+        case .timeoutError:
+            return "Timeout error"
+        }
+    }
 }

--- a/Tests/SimulatorTests/DeviceTests.swift
+++ b/Tests/SimulatorTests/DeviceTests.swift
@@ -105,6 +105,15 @@ final class DeviceTests: XCTestCase {
         try device.launchApp(bundleId)
     }
 
+    func test_wait() throws {
+        var device = try iPhoneDevice()
+        if device.isBooted {
+            _ = try device.kill()
+        }
+        try device.launch()
+        try device.wait(until: { $0.isBooted })
+    }
+
     private func mockShellInstance() {
         mockShell = Shell.mock()
         shell = mockShell

--- a/Tests/SimulatorTests/XcodeTests.swift
+++ b/Tests/SimulatorTests/XcodeTests.swift
@@ -16,7 +16,7 @@ final class XcodeTests: XCTestCase {
 
         subject = Xcode(shell: shell)
     }
-    
+
     override func tearDown() {
         super.tearDown()
         shell = Shell()


### PR DESCRIPTION
### Short description 📝
Add a new method `wait` to `Device`. It allows waiting until a certain device state is met:

```swift
try device.launch()
try device.wait(until: { $0.isBooted })
```
This PR also adds a new method, `reload()` which synchronizes the instance state with simctl.
