### PR TITLE
Change public interface to use Result instead of throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Bump Shell version to 1.0.1 https://github.com/tuist/simulator/pull/13 by @pepibumur
+- **Breaking** Use `Result` instead of throws in the public interface https://github.com/tuist/simulator/pull/14 by @pepibumur.
 
 ## 0.5.1
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
-github "tuist/shell" ~> 1.0.1
+github "tuist/shell" ~> 1.0.2
+github "antitypical/Result" ~> 4.0.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "antitypical/Result" "4.1.0"
 github "tuist/PathKit" "732bff7354542ac64f6515d8ea4895898084b9e1"
-github "tuist/shell" "1.0.1"
+github "tuist/shell" "1.0.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "antitypical/Result" "4.0.1"
+github "antitypical/Result" "4.1.0"
 github "tuist/PathKit" "732bff7354542ac64f6515d8ea4895898084b9e1"
 github "tuist/shell" "1.0.1"

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/tuist/Shell.git",
         "state": {
           "branch": null,
-          "revision": "1f02ced46a3f12f9a1bbe6b5629be9de928fb658",
-          "version": "1.0.1"
+          "revision": "712a57c49374e962bda2ed0692972be9c96a36df",
+          "version": "1.0.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -8,12 +8,13 @@ let package = Package(
         .library(name: "Simulator", type: .dynamic, targets: ["Simulator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/Shell.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/tuist/Shell.git", .upToNextMinor(from: "1.0.2")),
+        .package(url: "https://github.com/antitypical/Result.git", .upToNextMinor(from: "4.0.1")),
     ],
     targets: [
         .target(
             name: "Simulator",
-            dependencies: ["Shell"]
+            dependencies: ["Shell", "Result"]
         ),
         .testTarget(
             name: "SimulatorTests",

--- a/Simulator.podspec
+++ b/Simulator.podspec
@@ -13,5 +13,6 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/**/*.{swift}"
 
-  s.dependency "Shell", "~> 1.0.1"
+  s.dependency "Shell", "~> 1.0.2"
+  s.dependency "Result", "4.0.1"
 end

--- a/Sources/simulator/Runtime.swift
+++ b/Sources/simulator/Runtime.swift
@@ -106,9 +106,9 @@ public struct Runtime: Decodable, Equatable {
         }.mapError(SimulatorError.jsonSerialize)
         if runtimesDataResult.error != nil { return .failure(runtimesDataResult.error!) }
 
-        return Result {
+        return Result.init(catching: {
             try decoder.decode([Runtime].self, from: runtimesDataResult.value!)
-        }
+        })
     }
 
     /// Returns the latest runtime of a given platform.

--- a/Sources/simulator/Shell+Extras.swift
+++ b/Sources/simulator/Shell+Extras.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Shell
 import Result
+import Shell
 
 var shell = Shell()
 
@@ -8,43 +8,39 @@ extension Shell {
     /// Runs open with the given arguments.
     ///
     /// - Parameter arguments: Arguments to pass to open.
-    /// - Throws: An error if the command cannot be launched.
-    func open(_ arguments: [String]) throws {
+    /// - Returns: A result with a simulator error
+    func open(_ arguments: [String]) -> Result<Void, SimulatorError> {
         var arguments = arguments
         arguments.insert("/usr/bin/open", at: 0)
-
-        try sync(arguments).dematerialize()
+        return sync(arguments).mapError(SimulatorError.shell)
     }
 
-    /// Returns the path to Xcode.
+    /// Get the path to Xcode.
     ///
-    /// - Returns: Xcode path.
-    /// - Throws: A SimulatorError if Xcode can't be found in the system.
-    func xcodePath() throws -> URL {
-        let result = try capture(["/usr/bin/xcode-select", "-p"])
-        let path = try result.dematerialize().chomp()
-        return URL(fileURLWithPath: path, isDirectory: true)
+    /// - Returns: Xcode path or a simulator error.
+    func xcodePath() -> Result<URL, SimulatorError> {
+        let result = capture(["/usr/bin/xcode-select", "-p"])
+        return result.map({ URL(fileURLWithPath: $0.chomp(), isDirectory: true) }).mapError(SimulatorError.shell)
     }
 
     /// Runs simctl and returns its output.
     ///
     /// - Parameter arguments: Arguments to pass to simctl.
-    /// - Returns: The command output.
-    /// - Throws: A SimulatorError if the command fails.
-    func captureSimctl(_ arguments: [String]) throws -> String {
+    /// - Returns: The command output as a string or a simulator error.
+    func captureSimctl(_ arguments: [String]) -> Result<String, SimulatorError> {
         var arguments = arguments
         arguments.insert(contentsOf: ["/usr/bin/xcrun", "simctl"], at: 0)
-        return try capture(arguments).dematerialize().chomp()
+        return capture(arguments).map({ $0.chomp() }).mapError(SimulatorError.shell)
     }
 
     /// Runs the simctl command.
     ///
     /// - Parameter arguments: Arguments to pass to simctl.
-    /// - Throws: A SimulatorError if the command fails.
-    func runSimctl(_ arguments: [String]) throws {
+    /// - Returns: The command result.
+    func runSimctl(_ arguments: [String]) -> Result<Void, SimulatorError> {
         var arguments = arguments
         arguments.insert(contentsOf: ["/usr/bin/xcrun", "simctl"], at: 0)
 
-        try sync(arguments).dematerialize()
+        return sync(arguments).mapError(SimulatorError.shell)
     }
 }

--- a/Sources/simulator/SimulatorError.swift
+++ b/Sources/simulator/SimulatorError.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Shell
 
 public enum SimulatorError: Error, CustomStringConvertible {
     /// Thrown the underlying command doesn't return any output.
@@ -9,6 +10,9 @@ public enum SimulatorError: Error, CustomStringConvertible {
 
     /// Thrown when the JSON output cannot be decoded.
     case jsonDecode(Error)
+
+    /// Thrown when a plist file cannot be decoded.
+    case plistSerialize(Error)
 
     /// Thrown when the command output has an invalid/unexpected output.
     case invalidFormat
@@ -22,17 +26,17 @@ public enum SimulatorError: Error, CustomStringConvertible {
     /// Thrown when the simulator runtime profile cannot be found.
     case runtimeProfileNotFound
 
-    /// Thrown when the output from the launchtl list command cannot be parsed.
-    case invalidLaunchCtlListOutput
-
     /// Thrown when Xcode is not found using xcode-select
     case xcodeNotFound
 
     /// Thrown when a command exits unsuccessfully
-    case shellError(String?)
+    case shell(ShellError)
 
     /// Thrown when the method times out.
     case timeoutError
+
+    /// Thrown by the file manager.
+    case fileManager(Error)
 
     public var description: String {
         switch self {
@@ -50,18 +54,16 @@ public enum SimulatorError: Error, CustomStringConvertible {
             return "Runtime not found"
         case .runtimeProfileNotFound:
             return "Runtime profile not found"
-        case .invalidLaunchCtlListOutput:
-            return "Invalid launchctl output"
         case .xcodeNotFound:
             return "Xcode not found running xcode-select"
-        case let .shellError(error):
-            if let error = error {
-                return "Error running command: \(error)"
-            } else {
-                return "Error running command"
-            }
+        case let .shell(error):
+            return "Error running command: \(error)"
         case .timeoutError:
             return "Timeout error"
+        case let .plistSerialize(error):
+            return "Error serializing plist file: \(error)"
+        case let .fileManager(error):
+            return "File manager error: \(error)"
         }
     }
 }

--- a/Sources/simulator/Xcode.swift
+++ b/Sources/simulator/Xcode.swift
@@ -1,20 +1,20 @@
 import Foundation
+import Result
 import Shell
 
 protocol Xcoding {
-    /// Returns the path to the platform simulator SDK.
-    ///
-    /// - Parameter platform: Simulator platform.
-    /// - Returns: Path to the simulator SDK.
-    /// - Throws: An error if the path cannot be obtained.
-    func simulatorSDKPath(platform: Runtime.Platform) throws -> URL?
-
     /// Returns the path where the platform simulator runtimes are located.
     ///
     /// - Parameter platform: Platform whose runtime profiles will be returned.
     /// - Returns: Path to the simulator runtimes.
-    /// - Throws: An error if the path cannot be obtained.
-    func runtimeProfilesPath(platform: Runtime.Platform) throws -> URL?
+    /// - Returns: An error if the path cannot be obtained or a simulator error.
+    func simulatorSDKPath(platform: Runtime.Platform) -> Result<URL?, SimulatorError>
+
+    /// Returns the path to the platform simulator SDK.
+    ///
+    /// - Parameter platform: Simulator platform.
+    /// - Returns: A result with the path to the simulator SDK or a simulator error.
+    func runtimeProfilesPath(platform: Runtime.Platform) -> Result<URL?, SimulatorError>
 }
 
 /// Struct that provides some helper methods to read information from the Xcode environment.
@@ -36,25 +36,24 @@ struct Xcode: Xcoding {
     /// Returns the path to the platform simulator SDK.
     ///
     /// - Parameter platform: Simulator platform.
-    /// - Returns: Path to the simulator SDK.
-    /// - Throws: An error if the path cannot be obtained.
-    func runtimeProfilesPath(platform: Runtime.Platform) throws -> URL? {
+    /// - Returns: A result with the path to the simulator SDK or a simulator error.
+    func runtimeProfilesPath(platform: Runtime.Platform) -> Result<URL?, SimulatorError> {
         guard let device = devicePlatform(platform: platform) else {
-            return nil
+            return .success(nil)
         }
-        return try shell.xcodePath().appendingPathComponent("Platforms/\(device).platform/Developer/Library/CoreSimulator/Profiles/Runtimes/")
+        return shell.xcodePath().map({ $0.appendingPathComponent("Platforms/\(device).platform/Developer/Library/CoreSimulator/Profiles/Runtimes/") })
     }
 
     /// Returns the path where the platform simulator runtimes are located.
     ///
     /// - Parameter platform: Platform whose runtime profiles will be returned.
     /// - Returns: Path to the simulator runtimes.
-    /// - Throws: An error if the path cannot be obtained.
-    func simulatorSDKPath(platform: Runtime.Platform) throws -> URL? {
+    /// - Returns: An error if the path cannot be obtained or a simulator error.
+    func simulatorSDKPath(platform: Runtime.Platform) -> Result<URL?, SimulatorError> {
         guard let simulator = simulatorPlatform(platform: platform) else {
-            return nil
+            return .success(nil)
         }
-        return try shell.xcodePath().appendingPathComponent("Platforms/\(simulator).platform/Developer/SDKs/\(simulator).sdk/")
+        return shell.xcodePath().map({ $0.appendingPathComponent("Platforms/\(simulator).platform/Developer/SDKs/\(simulator).sdk/") })
     }
 
     /// Given a platform, it returns the name of the simulator platform to look it up in the Developer/Platforms directory.

--- a/Tests/SimulatorTests/DeviceTests.swift
+++ b/Tests/SimulatorTests/DeviceTests.swift
@@ -21,101 +21,106 @@ final class DeviceTests: XCTestCase {
         shell = Shell()
     }
 
-    func test_runtimePlatform() throws {
-        let device = try iPhoneDevice()
-        XCTAssertEqual(try device.runtimePlatform(), .iOS)
+    func test_runtimePlatform() {
+        let device = iPhoneDevice()
+        XCTAssertEqual(device.value?.runtimePlatform().value, .iOS)
     }
 
-    func test_deviceType() throws {
-        let device = try iPhoneDevice()
-        let deviceType = try device.deviceType()
-        XCTAssertEqual(deviceType, "com.apple.CoreSimulator.SimDeviceType.iPhone-XR")
+    func test_deviceType() {
+        let device = iPhoneDevice()
+        let deviceType = device.value?.deviceType()
+        XCTAssertEqual(deviceType?.value, "com.apple.CoreSimulator.SimDeviceType.iPhone-XR")
     }
 
-    func test_globalPreferences() throws {
-        let device = try iPhoneDevice()
-        let globalPreferences = try device.globalPreferences()
-        XCTAssertTrue(globalPreferences.keys.contains("AppleLocale"))
-        XCTAssertTrue(globalPreferences.keys.contains("AppleLanguages"))
+    func test_globalPreferences() {
+        let device = iPhoneDevice()
+        let globalPreferences = device.value?.globalPreferences().value
+        XCTAssertEqual(globalPreferences?.keys.contains("AppleLocale"), true)
+        XCTAssertEqual(globalPreferences?.keys.contains("AppleLanguages"), true)
     }
 
-    func test_plist() throws {
-        let device = try iPhoneDevice()
-        let plist = try device.plist()
-        XCTAssertTrue(plist.keys.contains("deviceType"))
-        XCTAssertTrue(plist.keys.contains("runtime"))
-        XCTAssertTrue(plist.keys.contains("UDID"))
-        XCTAssertTrue(plist.keys.contains("name"))
-        XCTAssertTrue(plist.keys.contains("state"))
+    func test_plist() {
+        let device = iPhoneDevice()
+        let plist = device.value?.plist().value
+        XCTAssertEqual(plist?.keys.contains("deviceType"), true)
+        XCTAssertEqual(plist?.keys.contains("runtime"), true)
+        XCTAssertEqual(plist?.keys.contains("UDID"), true)
+        XCTAssertEqual(plist?.keys.contains("name"), true)
+        XCTAssertEqual(plist?.keys.contains("state"), true)
     }
 
-    func test_runtimePath() throws {
-        let device = try iPhoneDevice()
-        XCTAssertNoThrow(try device.runtimePath())
+    func test_runtimePath() {
+        let device = iPhoneDevice().value
+        XCTAssertNil(device?.runtimePath().error)
     }
 
-    func test_launchCtlPath() throws {
-        let device = try iPhoneDevice()
-        let path = try device.launchCtlPath()
-        XCTAssertTrue(FileManager.default.fileExists(atPath: path.path))
+    func test_launchCtlPath() {
+        let device = iPhoneDevice().value
+        guard let path = device?.launchCtlPath().value?.path else {
+            XCTFail("Could not obtain launchctl path")
+            return
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path))
     }
 
-    func test_runtime() throws {
-        let device = try iPhoneDevice()
-        XCTAssertNoThrow(try device.runtime())
+    func test_runtime() {
+        let device = iPhoneDevice().value
+        XCTAssertNil(device?.runtime())
     }
 
-    func test_services() throws {
-        let device = try iPhoneDevice()
-        let services = try device.services()
-        XCTAssertTrue(services.contains(where: { $0.label == "com.apple.storeagent.daemon" }))
-        XCTAssertNotEqual(services.count, 0)
+    func test_services() {
+        let device = iPhoneDevice().value
+        let services = device?.services().value
+        XCTAssertEqual(services?.contains(where: { $0.label == "com.apple.storeagent.daemon" }), true)
+        XCTAssertNotEqual(services?.count, 0)
     }
 
-    func test_globalPreferencesPlistPath() throws {
-        let device = try iPhoneDevice()
-        let got = device.globalPreferencesPlistPath()
-        XCTAssertEqual(got, device.homePath().appendingPathComponent("data/Library/Preferences/.GlobalPreferences.plist"))
+    func test_globalPreferencesPlistPath() {
+        let device = iPhoneDevice().value
+        let got = device?.globalPreferencesPlistPath()
+        XCTAssertEqual(got, device?.homePath().appendingPathComponent("data/Library/Preferences/.GlobalPreferences.plist"))
     }
 
-    func test_devicePlistPath() throws {
-        let device = try iPhoneDevice()
-        let got = device.devicePlistPath()
-        XCTAssertEqual(got, device.homePath().appendingPathComponent("device.plist"))
+    func test_devicePlistPath() {
+        let device = iPhoneDevice().value
+        let got = device?.devicePlistPath()
+        XCTAssertEqual(got, device?.homePath().appendingPathComponent("device.plist"))
     }
 
-    func test_homePath() throws {
-        let device = try iPhoneDevice()
-        XCTAssertEqual(device.homePath(), Device.devicesPath().appendingPathComponent(device.udid))
+    func test_homePath() {
+        let device = iPhoneDevice().value
+        XCTAssertNotNil(device)
+        XCTAssertEqual(device?.homePath(), Device.devicesPath().appendingPathComponent(device!.udid))
     }
 
-    func test_list_returns_a_non_empty_list() throws {
-        let got = try Device.list()
-        XCTAssertNotEqual(got.count, 0)
+    func test_list_returns_a_non_empty_list() {
+        let got = Device.list().value
+        XCTAssertNotEqual(got?.count, 0)
     }
 
-    func testLaunch() throws {
+    func testLaunch() {
         mockShellInstance()
         mockShell.stub(["/usr/bin/xcode-select", "-p"], stdout: ["/xcode/path"], stder: [], code: 0)
         mockShell.succeed(["/usr/bin/open", "-Fgn", "/xcode/path/Applications/Simulator.app", "--args", "-CurrentDeviceUDID", self.device.udid])
 
-        try device.launch()
+        XCTAssertNil(device.launch().error)
     }
 
-    func testLaunchApp() throws {
+    func testLaunchApp() {
         mockShellInstance()
         let bundleId = "best.app.ever"
         mockShell.stub(["/usr/bin/xcrun", "simctl", "launch", self.device.udid, bundleId], stdout: ["/xcode/path"], stder: [], code: 0)
-        try device.launchApp(bundleId)
+        XCTAssertNil(device.launchApp(bundleId).error)
     }
 
-    func test_wait() throws {
-        var device = try iPhoneDevice()
-        if device.isBooted {
-            _ = try device.kill()
+    func test_wait() {
+        var device = iPhoneDevice().value
+        if device?.isBooted == true {
+            _ = device?.kill()
         }
-        try device.launch()
-        try device.wait(until: { $0.isBooted })
+        _ = device?.launch()
+        let got = device?.wait(until: { $0.isBooted })
+        XCTAssertNil(got?.error)
     }
 
     private func mockShellInstance() {

--- a/Tests/SimulatorTests/DeviceTests.swift
+++ b/Tests/SimulatorTests/DeviceTests.swift
@@ -65,7 +65,7 @@ final class DeviceTests: XCTestCase {
 
     func test_runtime() {
         let device = iPhoneDevice().value
-        XCTAssertNil(device?.runtime())
+        XCTAssertNil(device?.runtime().error)
     }
 
     func test_services() {

--- a/Tests/SimulatorTests/Mocks/MockXcode.swift
+++ b/Tests/SimulatorTests/Mocks/MockXcode.swift
@@ -1,16 +1,17 @@
 import Foundation
+import Result
 
 @testable import Simulator
 
 final class MockXcode: Xcoding {
-    var simulatorSDKPathStub: ((Runtime.Platform) throws -> URL?)?
-    var runtimeProfilesPathStub: ((Runtime.Platform) throws -> URL?)?
+    var simulatorSDKPathStub: ((Runtime.Platform) -> Result<URL?, SimulatorError>)?
+    var runtimeProfilesPathStub: ((Runtime.Platform) -> Result<URL?, SimulatorError>)?
 
-    func simulatorSDKPath(platform: Runtime.Platform) throws -> URL? {
-        return try simulatorSDKPathStub?(platform)
+    func simulatorSDKPath(platform: Runtime.Platform) -> Result<URL?, SimulatorError> {
+        return simulatorSDKPathStub?(platform) ?? .success(nil)
     }
 
-    func runtimeProfilesPath(platform: Runtime.Platform) throws -> URL? {
-        return try runtimeProfilesPathStub?(platform)
+    func runtimeProfilesPath(platform: Runtime.Platform) -> Result<URL?, SimulatorError> {
+        return simulatorSDKPathStub?(platform) ?? .success(nil)
     }
 }

--- a/Tests/SimulatorTests/RuntimeTests.swift
+++ b/Tests/SimulatorTests/RuntimeTests.swift
@@ -4,12 +4,12 @@ import XCTest
 @testable import Simulator
 
 final class RuntimeTests: XCTestCase {
-    func test_list() throws {
+    func test_list() {
         let got = Runtime.list().value
         XCTAssertNotEqual(got?.count, 0)
     }
 
-    func test_latest() throws {
+    func test_latest() {
         let got = Runtime.latest(platform: .iOS).value
         XCTAssertNotNil(got ?? nil)
     }

--- a/Tests/SimulatorTests/RuntimeTests.swift
+++ b/Tests/SimulatorTests/RuntimeTests.swift
@@ -5,12 +5,12 @@ import XCTest
 
 final class RuntimeTests: XCTestCase {
     func test_list() throws {
-        let got = try XCTTry(Runtime.list())
-        XCTAssertNotEqual(got.count, 0)
+        let got = Runtime.list().value
+        XCTAssertNotEqual(got?.count, 0)
     }
 
     func test_latest() throws {
-        let got = try XCTTry(Runtime.latest(platform: .iOS))
-        XCTAssertNotNil(got)
+        let got = Runtime.latest(platform: .iOS).value
+        XCTAssertNotNil(got ?? nil)
     }
 }

--- a/Tests/SimulatorTests/XCTestCase+Extras.swift
+++ b/Tests/SimulatorTests/XCTestCase+Extras.swift
@@ -1,43 +1,15 @@
 import Foundation
+import Result
 @testable import Simulator
 import XCTest
 
 extension XCTestCase {
-    /// Returns an iPhone device from the system to be used from the tests.
-    ///
-    /// - Returns: Device instance from the system.
-    /// - Throws: An error if simctl errors or the iPhone device can't be found.
-    func iPhoneDevice(type: String = "iPhone XR") throws -> Device {
-        guard let device = try Device.list().first(where: { $0.name == type && $0.isAvailable == true }) else {
-            throw AnyError(description: "Couldn't find a valid iPhone")
-        }
-        return device
-    }
-
-    /// Tries to run the closure and if it throws, it prints and re-throws the error.
-    ///
-    /// - Parameter closure: Closure to be run.
-    /// - Throws: If the given closure throws.
-    func XCTTry(_ closure: @autoclosure () throws -> Void) throws {
-        do {
-            try closure()
-        } catch {
-            print(error)
-            throw error
-        }
-    }
-
-    /// Tries to run the closure and if it throws, it prints and re-throws the error.
-    ///
-    /// - Parameter closure: Closure to be run.
-    /// - Returns: The value returned by the closure.
-    /// - Throws: If the given closure throws.
-    func XCTTry<T>(_ closure: @autoclosure () throws -> T) throws -> T {
-        do {
-            return try closure()
-        } catch {
-            print(error)
-            throw error
-        }
+    func iPhoneDevice(type: String = "iPhone XR") -> Result<Device, AnyError> {
+        return Device.list().mapError({ AnyError(description: $0.description) }).flatMap({ (devices) -> Result<Device, AnyError> in
+            guard let device = devices.first(where: { $0.name == type && $0.isAvailable == true }) else {
+                return .failure(AnyError(description: "Couldn't obtain device of type \(type)"))
+            }
+            return .success(device)
+        })
     }
 }

--- a/Tests/SimulatorTests/XcodeTests.swift
+++ b/Tests/SimulatorTests/XcodeTests.swift
@@ -44,7 +44,7 @@ final class XcodeTests: XCTestCase {
         XCTAssertNil(got.value ?? nil)
     }
 
-    func test_devicePlatform() throws {
+    func test_devicePlatform() {
         XCTAssertEqual(subject.devicePlatform(platform: .iOS), "iPhoneOS")
         XCTAssertEqual(subject.devicePlatform(platform: .watchOS), "WatchOS")
         XCTAssertEqual(subject.devicePlatform(platform: .tvOS), "AppleTVOS")

--- a/Tests/SimulatorTests/XcodeTests.swift
+++ b/Tests/SimulatorTests/XcodeTests.swift
@@ -22,30 +22,26 @@ final class XcodeTests: XCTestCase {
         shell = Shell()
     }
 
-    func test_runtimeProfilesPath() throws {
+    func test_runtimeProfilesPath() {
         mockShell.stub(["/usr/bin/xcode-select", "-p"], stdout: ["/xcode"], stder: [], code: 0)
-        guard let got = try subject.runtimeProfilesPath(platform: .iOS) else {
-            XCTFail("Expected simulatorSDKPath to return a value")
-            return
-        }
-        XCTAssertEqual(got, URL(fileURLWithPath: "/xcode/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes"))
+        let got = subject.runtimeProfilesPath(platform: .iOS)
+        XCTAssertEqual(got.value, URL(fileURLWithPath: "/xcode/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes"))
     }
 
-    func test_runtimeProfilesPath_when_platformHasNoSimulator() throws {
-        XCTAssertNil(try subject.runtimeProfilesPath(platform: .unknown))
+    func test_runtimeProfilesPath_when_platformHasNoSimulator() {
+        let got = subject.runtimeProfilesPath(platform: .unknown)
+        XCTAssertNil(got.value ?? nil)
     }
 
-    func test_simulatorSDKPath() throws {
+    func test_simulatorSDKPath() {
         mockShell.stub(["/usr/bin/xcode-select", "-p"], stdout: ["/xcode"], stder: [], code: 0)
-        guard let got = try subject.simulatorSDKPath(platform: .iOS) else {
-            XCTFail("Expected simulatorSDKPath to return a value")
-            return
-        }
-        XCTAssertEqual(got, URL(fileURLWithPath: "/xcode/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"))
+        let got = subject.simulatorSDKPath(platform: .iOS)
+        XCTAssertEqual(got.value, URL(fileURLWithPath: "/xcode/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"))
     }
 
-    func test_simulatorSDKPath_when_platformHasNoSimulators() throws {
-        XCTAssertNil(try subject.simulatorSDKPath(platform: .unknown))
+    func test_simulatorSDKPath_when_platformHasNoSimulators() {
+        let got = subject.simulatorSDKPath(platform: .unknown)
+        XCTAssertNil(got.value ?? nil)
     }
 
     func test_devicePlatform() throws {


### PR DESCRIPTION
### Short description 📝
Change the public interface to return `Result` types instead of using Swift throws. They provide more information about the error that is being returned.